### PR TITLE
fix(docker) Update base image to slim-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 LABEL base_image="python:3.10-slim"
 LABEL about.home="https://github.com/Clinical-Genomics/arnold"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ coveralls<5
 pylint
 mock
 pydantic[dotenv]
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 PyYAML
-pydantic
+pydantic<2.0.0
 fastapi
 pandas
 gunicorn


### PR DESCRIPTION
### Description
After an update to the python3.XX-slim base images, Gunicorn has problems creating threads. However python3.XX-slim-bullseye does not.

### Added

### Changed
- base image from `python:3.10-slim` to `python:3.10-slim-bullseye`

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


